### PR TITLE
Add Checkstyle code analysis to Maven build and CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven (Build, Test & Coverage)
+name: Java CI (Build, Coverage & Analysis)
 
 on:
   push:
@@ -29,23 +29,30 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
-    # MODIFIED STEP: Added 'jacoco:report' to generate the coverage HTML
-    - name: Build and Measure Coverage
-      run: mvn -B package jacoco:report --file pom.xml
+    # Run Build + JaCoCo (Coverage) + Checkstyle (Code Analysis)
+    - name: Build, Test, and Analyze
+      run: mvn -B package jacoco:report checkstyle:checkstyle --file pom.xml
 
-    # ORIGINAL STEP: Keep your existing JAR upload
+    # Artifact 1: The JAR file
     - name: Upload Maven Artifact (JAR)
       uses: actions/upload-artifact@v4
       with:
-        name: msisdn-format-checker-jar
+        name: application-jar
         path: target/*.jar
 
-    # NEW STEP: Upload the JaCoCo HTML report so you can download it
+    # Artifact 2: Test Coverage Report (JaCoCo)
     - name: Upload JaCoCo Coverage Report
       uses: actions/upload-artifact@v4
       with:
-        name: jacoco-coverage-report
+        name: coverage-report
         path: target/site/jacoco/
+
+    # Artifact 3: Code Analysis Report (Checkstyle)
+    - name: Upload Code Analysis Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-analysis-report
+        path: target/site/checkstyle.html
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     # - name: Update dependency graph
     #   uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,21 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<configLocation>sun_checks.xml</configLocation>
+					<failOnViolation>false</failOnViolation> </configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>checkstyle</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Integrated the maven-checkstyle-plugin into pom.xml for code analysis using Sun checks. Updated the GitHub Actions workflow to run Checkstyle during CI, and to upload the Checkstyle report as an artifact alongside the JAR and JaCoCo coverage report.