### PR TITLE
Bump libphonenumber to 9.0.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.googlecode.libphonenumber</groupId>
 			<artifactId>libphonenumber</artifactId>
-			<version>9.0.35</version>
+			<version>9.0.36</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>


### PR DESCRIPTION
## Summary
- Bumped `com.googlecode.libphonenumber:libphonenumber` from `9.0.35` to `9.0.36`, the latest release published by Google on the [libphonenumber GitHub releases page](https://github.com/google/libphonenumber/releases).

## Test plan
- [x] `mvn compile` succeeds with the updated dependency version.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012VE7gbAji5CJjimhKBY6SJ)_